### PR TITLE
More notices

### DIFF
--- a/custom-post-types.php
+++ b/custom-post-types.php
@@ -421,7 +421,7 @@ abstract class CustomPostType {
 	/**
 	 * Outputs this item in HTML.  Can be overridden for descendants.
 	 * */
-	public function toHTML( $object ) {
+	public static function toHTML( $object ) {
 		$html = '<a href="'.get_permalink( $object->ID ).'">'.$object->post_title.'</a>';
 		return $html;
 	}
@@ -533,7 +533,7 @@ class IconLink extends CustomPostType {
 		);
 	}
 
-	public function toHTML( $object ) {
+	public static function toHTML( $object ) {
 		$icon = get_field( 'icon_link_icon', $object->ID );
 		$url = get_field( 'icon_link_url', $object->ID );
 		ob_start();
@@ -607,7 +607,7 @@ class Spotlight extends CustomPostType {
 		);
 	}
 
-	public function toHTML( $object ) {
+	public static function toHTML( $object ) {
 		$image_url = has_post_thumbnail( $object->ID ) ?
 			wp_get_attachment_image_src( get_post_thumbnail_id( $object->ID ), 'spotlight' ) :
 			null;
@@ -780,7 +780,7 @@ class Section extends CustomPostType {
 		);
 	}
 
-	function add_post_meta( $object ) {
+	public static function add_post_meta( $object ) {
 
 		$post_id    = $object->ID;
 		$prefix     = 'section_';
@@ -801,7 +801,7 @@ class Section extends CustomPostType {
 		return $object;
 	}
 
-	public function toHTML( $object ) {
+	public static function toHTML( $object ) {
 		$object = Section::add_post_meta( $object );
 		ob_start();
 ?>

--- a/functions/custom-fields.php
+++ b/functions/custom-fields.php
@@ -35,7 +35,7 @@ if ( class_exists( 'acf_field' ) ){
 
 		function create_field( $field ) {
 	?>
-		<?php echo $this->icon_field_modal_html(); ?>
+		<?php echo $this->icon_field_modal_html( $field ); ?>
 		<div class="meta-icon-wrapper">
 			<div class="meta-icon-preview">
 				<?php if ( $field['value'] ) : ?>
@@ -55,6 +55,7 @@ if ( class_exists( 'acf_field' ) ){
 		}
 
 		function icon_field_modal_html( $field ) {
+			$icons = $this->get_fa_icons();
 			ob_start();
 	?>
 			<div id="meta-icon-modal" style="display: none;">
@@ -63,11 +64,15 @@ if ( class_exists( 'acf_field' ) ){
 				<p>
 					<input type="text" placeholder="search" id="meta-icon-search">
 				</p>
+
+				<?php if ( ! empty( $icons ) ): ?>
 				<ul class="meta-fa-icons">
-				<?php foreach( $this->get_fa_icons() as $icon ) : ?>
-					<li class="meta-fa-icon"><i class="fa <?php echo $icon; ?>" data-icon-value="<?php echo $icon; ?>"></i></li>
-				<?php endforeach; ?>
+					<?php foreach( $icons as $icon ) : ?>
+						<li class="meta-fa-icon"><i class="fa <?php echo $icon; ?>" data-icon-value="<?php echo $icon; ?>"></i></li>
+					<?php endforeach; ?>
 				</ul>
+				<?php endif; ?>
+
 				<div class="meta-icon-modal-footer">
 					<button type="button" id="meta-icon-submit">Submit</button>
 				</div>
@@ -78,9 +83,9 @@ if ( class_exists( 'acf_field' ) ){
 		}
 
 		function get_fa_icons() {
-			$response      = wp_remote_get( $url, array( 'timeout' => 15 ) );
+			$response      = wp_remote_get( THEME_DATA_URL . '/fa-icons.json', array( 'timeout' => 15 ) );
 			$response_code = wp_remote_retrieve_response_code( $response );
-			$result        = '';
+			$result        = array();
 
 			if ( is_array( $response ) && is_int( $response_code ) && $response_code < 400 ) {
 				$result = json_decode( wp_remote_retrieve_body( $response ) );

--- a/functions/custom-fields.php
+++ b/functions/custom-fields.php
@@ -78,16 +78,15 @@ if ( class_exists( 'acf_field' ) ){
 		}
 
 		function get_fa_icons() {
-			$opts = array(
-				'http' => array(
-					'timeout' => 15
-				)
-			);
+			$response      = wp_remote_get( $url, array( 'timeout' => 15 ) );
+			$response_code = wp_remote_retrieve_response_code( $response );
+			$result        = '';
 
-			$context = stream_context_create( $opts );
+			if ( is_array( $response ) && is_int( $response_code ) && $response_code < 400 ) {
+				$result = json_decode( wp_remote_retrieve_body( $response ) );
+			}
 
-			$contents = file_get_contents( THEME_DATA_URL . '/fa-icons.json', false, $context );
-			return json_decode( $contents );
+			return $result;
 		}
 	}
 

--- a/shortcodes.php
+++ b/shortcodes.php
@@ -53,13 +53,15 @@ abstract class Shortcode {
         <li class="shortcode-<?php echo $this->command; ?>">
             <h3><?php echo $this->name; ?> Options</h3>
 <?php
-        foreach($this->params as $param) :
+		if ( ! empty( $this->params ) ):
+			foreach( $this->params as $param ):
+				echo $this->get_field_input( $param, $this->command );
+			endforeach;
+		else:
 ?>
-            <h4><?php echo $param->name; ?></h4>
-            <p class="help"><?php echo $param->help_text; ?></p>
-            <?php echo $this->get_field_input( $param, $this->command ); ?>
+		<p>No options available.</p>
 <?php
-        endforeach;
+		endif;
 ?>
         </li>
 <?php


### PR DESCRIPTION
Cleaned up a few more notices and warnings:

- Made custom post type objects' `toHTML` methods static, since usage in the theme expects this method to be static
- Fixed usage of `$this->icon_field_modal_html()` without required 1st argument
- Fixed instances of looping through potentially empty results
- Replaced usage of `file_get_contents()` for fetching a font icon list with `wp_remote_get()`